### PR TITLE
Some tidy up and extend support for 3.10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     strategy:
         matrix:
-          python: [3.11]
+          python: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.11]
+        python: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,3 +1,147 @@
 # uglylogger
 
 An ugly, slow Logger class for python
+
+## FAQ
+
+### Why required python version is equal or greater than 3.10?  
+- match .. case .. is introduced in [3.10](https://docs.python.org/3/whatsnew/3.10.html) and I am not interested in supporting older releases  
+
+### Why is it ugly?
+- I am not an expert on Python
+- It is not thread-safe
+- I don't know what happens if two instances are created with the same name, and I don't care. I'd never do that
+- The solo purpose is to have an easy to use and easy to read logger class
+
+### Why is it ugly but not that ugly?
+- it is easy to use and easy to read
+- I may keep this library up-to-date and even optimize it in the future
+- at least it has a CI/CD pipeline
+
+## Installation
+
+`pip install uglylogger`
+
+## Release Notes
+
+[Release notes](RELEASE_NOTES.md)  
+
+## Usage
+
+### Instantiate
+```
+# A logger which can log both to console and to a file
+logger = Logger("name", "file.log")  
+
+# A logger which can only log to console
+logger = Logger("name")  
+```
+
+### Release the resources
+```
+logger.release()
+```
+- Releases the resources, it's safe to delete the log file after calling this method
+
+### Color Mode
+```
+logger.set_color_mode(LogColorMode.COLORED)
+```
+- coloroed output if the console/terminal supports it
+```
+logger.set_color_mode(LogColorMode.MONO)
+```
+- no color used for the console/terminal output
+
+### Log to console
+```
+logger.console("Message", color=LogColor.BLACK, level=LogLevel.DEBUG)
+```
+- color and level are optional
+- if not provided, default color is BLACK
+- if not provided, default level is DEBUG
+
+### Log to file
+```
+logger.file("Message", level=LogLevel.DEBUG)
+```
+- level is optional
+- if not provided, default level is DEBUG
+- if instantiated without a file name, nothing happens
+
+### Log to both file and console
+```
+logger.log("Message", color=LogColor.BLACK, level=LogLevel.DEBUG, output=LogOutput.ALL)
+```
+- color, level and output are optional
+- if not provided, default color is BLACK
+- if not provided, default level is DEBUG
+- if not provided, default output is ALL
+- if instantiated without a file name, writing to file is ignored
+
+
+### Other ways of logging
+
+`logger.debug("Message", color=LogColor.BLACK, output=LogOutput.ALL)`  
+`logger.info("Message", color=LogColor.BLACK, output=LogOutput.ALL)`  
+`logger.warning("Message", color=LogColor.BLACK, output=LogOutput.ALL)`  
+`logger.error("Message", color=LogColor.BLACK, output=LogOutput.ALL)`  
+`logger.critical("Message", color=LogColor.BLACK, output=LogOutput.ALL)`  
+
+### Available LogColor
+    - BLACK
+    - RED
+    - GREEN
+    - YELLOW
+    - BLUE
+    - MAGENTA
+    - CYAN
+    - WHITE
+
+### Available LogLevel
+    - DEBUG
+    - INFO
+    - WARNING
+    - ERROR
+    - CRITICAL
+
+### Available LogOutput
+    - NONE
+    - CONSOLE
+    - FILE
+    - ALL
+
+## set log format
+```
+logger.set_format([
+    ...
+    LogFormatBlock.XXX
+    ...
+])
+```
+
+### Available LogFormatBlock
+    - NAME
+    - LEVEL
+    - DATETIME
+    - MESSAGE
+    - FILE
+    - LINE
+    - FUNCTION
+
+### Example Formats
+```
+logger.set_format([LogFormatBlock.MESSAGE])
+logger.console("Hello World!")
+# Output : Hello World!
+```
+```
+logger.set_format([
+    "[",
+    LogFormatBlock.LEVEL,
+    "] ",
+    LogFormatBlock.MESSAGE]
+)
+logger.console("Hello World!")
+# Output : [DEBUG] Hello World!
+```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,18 @@
+# v0.3.0  
+- **[FEATURE]** Added Python 3.10 support
+- **[FEATURE]** Added Python 3.12 support
+- **[DOC]** Added Release Notes
+- **[DOC]** Updated README
+- **[FEATURE]** Fixed __init__.py so the module can now be used as  
+`from uglylogger import Logger`  
+instead of  
+`from uglylogger.logger import Logger`  
+
+# v0.2.0
+- **[FEATURE]** introduced logger.console_oneline() method which enables user to print to a single console row (Useful for progress output)  
+
+# v0.1.1
+- **[FEATURE]** logger.log() method now accepts *LogOutput* as an argument  
+
+# v0.1.0
+- **[INITIAL]** Initial Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "uglylogger"  # Required
-version = "0.2.0"  # Required
+version = "0.3.0"  # Required
 description = "An ugly, slow Logger class for python"  # Optional
 readme = "README.md" # Optional
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = ["python", "python3", "log", "logger", "oop","pretty", "ugly"]  # Optional
 authors = [

--- a/src/uglylogger/__init__.py
+++ b/src/uglylogger/__init__.py
@@ -1,0 +1,8 @@
+from .logger import (
+    LogColorMode,
+    LogColor,
+    LogOutput,
+    LogLevel,
+    LogFormatBlock,
+    Logger,
+)

--- a/src/uglylogger/logger.py
+++ b/src/uglylogger/logger.py
@@ -256,9 +256,6 @@ class Logger:
     def _msg_to_str(self, msg: typing.Any) -> str:
         return str(msg, "utf-8") if type(msg) is bytes else str(msg)
 
-    def set_format(self, fmt: list = []):
-        self._format_arr = fmt
-
     def _get_file_line_func(self):
         stack = inspect.stack()
         this_fil = str(stack[1][1])
@@ -326,6 +323,9 @@ class Logger:
                 self._color_str(color) + self._format(msg, level) + "\033[0m"
             )
         return self._format(msg, level)
+
+    def set_format(self, fmt: list = []):
+        self._format_arr = fmt
 
     def console_oneline(
         self,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ import unittest
 import unittest.mock
 import os
 from inspect import currentframe, getframeinfo
-from uglylogger.logger import Logger, LogFormatBlock, LogColorMode
+from uglylogger import Logger, LogFormatBlock, LogColorMode
 
 
 class TestMain(unittest.TestCase):
@@ -137,7 +137,7 @@ class TestMain(unittest.TestCase):
     def test_log_file_creation(self):
         file_name = "test_log_file_creation.log"
         logger = self._create_logger("test_log_file_creation", file_name)
-        logger.set_format(LogFormatBlock.MESSAGE)
+        logger.set_format([LogFormatBlock.MESSAGE])
         logger.debug("DEBUG LOG HERE")
         self.assertEqual(
             True, os.path.exists(file_name), f"{file_name} file not found"
@@ -147,7 +147,7 @@ class TestMain(unittest.TestCase):
     def test_log_file_contains_content(self):
         file_name = "test_log_file_contains_content.log"
         logger = self._create_logger("debug_logger", file_name)
-        logger.set_format(LogFormatBlock.MESSAGE)
+        logger.set_format([LogFormatBlock.MESSAGE])
         log_line = "DEBUG LOG HERE"
         logger.debug(log_line)
         last_line_in_file = self._read_line_of_log_file(file_name, -1)
@@ -174,7 +174,7 @@ class TestMain(unittest.TestCase):
     def test_levels(self):
         file = "test_levels.log"
         logger = self._create_logger("test_levels", file)
-        logger.set_format(LogFormatBlock.MESSAGE)
+        logger.set_format([LogFormatBlock.MESSAGE])
         # debug
         logger.debug("DEBUG")
         line = self._read_line_of_log_file(logger._file)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]black
 requires = tox>=4
-envlist = py{311}
+envlist = py{310, 311, 312}
 isolated_env=false
 
 [testenv]
@@ -20,9 +20,12 @@ commands =
     coverage report
 
 [flake8]
-exclude = .tox,*.egg,build,data
+exclude = .tox,*.egg,build,data,venv
 select = E,W,F
 docstring-convention = numpy
+per-file-ignores = 
+    # imported but unused
+    __init__.py: F401  
 
 [black]
 line-length = 79


### PR DESCRIPTION
- **[FEATURE]** Added Python 3.10 support
- **[FEATURE]** Added Python 3.12 support
- **[DOC]** Added Release Notes
- **[DOC]** Updated README
- **[FEATURE]** Fixed __init__.py so the module can now be used as `from uglylogger import Logger`
instead of
`from uglylogger.logger import Logger`